### PR TITLE
Add German strings

### DIFF
--- a/src/strings.json
+++ b/src/strings.json
@@ -52,5 +52,11 @@
     "online": "{{count}} у мережі",
     "members": "{{count}} учасників",
     "button": "Приєднатися"
+  },
+  "de": {
+    "header": "Du wurdest eingeladen, einem Server beizutreten",
+    "online": "{{count}} online",
+    "members": "{{count}} Mitglieder",
+    "button": "Beitreten"
   }
 }


### PR DESCRIPTION
This adds Discord's translation strings for German as a language option.