### PR TITLE
add api v10

### DIFF
--- a/src/Discord.js
+++ b/src/Discord.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch')
 
-const API_BASE_URL = 'https://discord.com/api/v6'
+const API_BASE_URL = 'https://discord.com/api/v10'
 const CDN_BASE_URL = 'https://cdn.discordapp.com'
 
 module.exports = class Discord {


### PR DESCRIPTION
Discord's api v6 will no longer be available after April 30, 2022, and this will cause invidget to break

([Source (from discord developers)](https://discord.com/channels/613425648685547541/697138785317814292/942829119077507112))