### PR TITLE
fix jpeg mime type

### DIFF
--- a/src/InviteRenderer.js
+++ b/src/InviteRenderer.js
@@ -131,7 +131,7 @@ module.exports = class InviteRenderer {
     const squircle = contentContainer.rect(ICON_SIZE, ICON_SIZE).radius(16).fill(themeColors.serverIcon)
     if (invite.guild.icon) {
       const iconBase64 = await Discord.fetchIcon(Discord.getIconUrl(invite.guild.id, invite.guild.icon))
-      const iconImage = contentContainer.image(`data:image/${invite.guild.icon.startsWith('a_') ? 'gif' : 'jpg'};base64,${iconBase64}`).size(ICON_SIZE, ICON_SIZE)
+      const iconImage = contentContainer.image(`data:image/${invite.guild.icon.startsWith('a_') ? 'gif' : 'jpeg'};base64,${iconBase64}`).size(ICON_SIZE, ICON_SIZE)
       iconImage.clipWith(squircle)
     }
 


### PR DESCRIPTION
image/jpg is not a valid mime type and is not recognised by all programs. the correct mime type is image/jpeg. I noticed this because i was trying to feed the svg into librsvg and it doesn't recognise it as a valid data url. https://gitlab.gnome.org/GNOME/librsvg/-/issues/389

https://stackoverflow.com/questions/33692835/is-the-mime-type-image-jpg-the-same-as-image-jpeg